### PR TITLE
ci(exercise): fix issues write permissions

### DIFF
--- a/.github/workflows/exercise.yml
+++ b/.github/workflows/exercise.yml
@@ -1,10 +1,11 @@
 name: Exercise
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   exercise1:

--- a/.github/workflows/exercise.yml
+++ b/.github/workflows/exercise.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   exercise1:
   # create a new issue and assign it to who commented


### PR DESCRIPTION
由于没有写 issue 的权限，导致自动创建完 issue 后无法分配到指定人。

close #42